### PR TITLE
Update podinfo CLI to 1.4.2

### DIFF
--- a/Formula/podcli.rb
+++ b/Formula/podcli.rb
@@ -1,9 +1,9 @@
 class Podcli < Formula
   desc "podinfo command line utilities"
   homepage "https://github.com/stefanprodan/k8s-podinfo"
-  version "1.3.1"
+  version "1.4.2"
   url "https://github.com/stefanprodan/k8s-podinfo/releases/download/v#{version}/podcli_#{version}_darwin_amd64.tar.gz"
-  sha256 "c6ce58d593cf4a29e8e617a7bf8ff9777982206795adf3cbaa1216c0d75012e1"
+  sha256 "598cebe27fcee1fa8a16b76a09d1df5a029c29a406e2cd0a9794dab4ce7bab15"
   
   def install
     bin.install "podcli"


### PR DESCRIPTION
- includes TravisCI/Quay repo bootstrap similar to GitHub Actions/Docker Hub