### PR TITLE
Migrate eksctl to homebrew-core

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,4 @@
 {
-  "aws-iam-authenticator": "homebrew/core"
+  "aws-iam-authenticator": "homebrew/core",
+  "eksctl": "homebrew/core"
 }


### PR DESCRIPTION
Migrates `eksctl` to the homebrew-core repository https://github.com/Homebrew/homebrew-core/pull/58282
Additionally the `eksctl` formula may be deleted here. I leave that up for you to decide.

related PR: https://github.com/weaveworks/eksctl/pull/2462