### PR TITLE
Adds a WGEAuthDownloadStrategy that can be used by Formula

### DIFF
--- a/Formula/lib/curl_user_download_strategy.rb
+++ b/Formula/lib/curl_user_download_strategy.rb
@@ -1,8 +1,0 @@
-class CurlUserDownloadStrategy < CurlDownloadStrategy
-  def initialize(url, name, version, **meta)
-    meta ||= {}
-    meta[:user] ||= ENV['HOMEBREW_CURL_USER']
-    super(url, name, version, meta)
-  end
-end
-

--- a/Formula/lib/curl_user_download_strategy.rb
+++ b/Formula/lib/curl_user_download_strategy.rb
@@ -1,0 +1,8 @@
+class CurlUserDownloadStrategy < CurlDownloadStrategy
+  def initialize(url, name, version, **meta)
+    meta ||= {}
+    meta[:user] ||= ENV['HOMEBREW_CURL_USER']
+    super(url, name, version, meta)
+  end
+end
+

--- a/Formula/lib/wge_auth_download_strategy.rb
+++ b/Formula/lib/wge_auth_download_strategy.rb
@@ -1,0 +1,8 @@
+class WGEAuthDownloadStrategy < CurlDownloadStrategy
+  def initialize(url, name, version, **meta)
+    meta ||= {}
+    meta[:user] ||= "#{ENV['HOMEBREW_WGE_USERNAME']}:#{ENV['HOMEBREW_WGE_PASSWORD']}"
+    super(url, name, version, meta)
+  end
+end
+


### PR DESCRIPTION
Reads HOMEBREW_WGE_USERNAME AND HOMEBREW_WGE_PASSWORD from the local env. e.g:

```
HOMEBREW_WGE_USERNAME="user" HOMEBREW_WGE_PASSWORD="$PASSWORD" brew install weaveworks/tap/gitops-ee
```

Uses https://github.com/Homebrew/brew/blob/master/Library/Homebrew/download_strategy.rb#L371 and follows the `meta` updating pattern found in the other DownloadStrategies in that file.

It seems `meta[:user]` has been around for 5 years or so, and is hopefully fairly stable.