### PR TITLE
fix kwargs for gitops formula

### DIFF
--- a/Formula/gitops.rb
+++ b/Formula/gitops.rb
@@ -15,11 +15,11 @@ class Gitops < Formula
       def install
         bin.install "gitops"
         # Install bash completion
-        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", err: :err)
         (bash_completion/"gitops").write output
 
         # Install zsh completion
-        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", err: :err)
         (zsh_completion/"_gitops").write output
       end
     end
@@ -30,11 +30,11 @@ class Gitops < Formula
       def install
         bin.install "gitops"
         # Install bash completion
-        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", err: :err)
         (bash_completion/"gitops").write output
 
         # Install zsh completion
-        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", err: :err)
         (zsh_completion/"_gitops").write output
       end
     end
@@ -48,11 +48,11 @@ class Gitops < Formula
       def install
         bin.install "gitops"
         # Install bash completion
-        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", err: :err)
         (bash_completion/"gitops").write output
 
         # Install zsh completion
-        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", err: :err)
         (zsh_completion/"_gitops").write output
       end
     end
@@ -63,11 +63,11 @@ class Gitops < Formula
       def install
         bin.install "gitops"
         # Install bash completion
-        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", err: :err)
         (bash_completion/"gitops").write output
 
         # Install zsh completion
-        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", { :err => :err })
+        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", err: :err)
         (zsh_completion/"_gitops").write output
       end
     end


### PR DESCRIPTION
Closes https://github.com/weaveworks/homebrew-tap/issues/36

Applies suggestion from https://github.com/weaveworks/homebrew-tap/issues/36#issuecomment-1841549567

```bash 
Cask 'gitops' is unreadable: wrong constant name #<Class:0x0000000127d5e3f0>
Warning: Treating /Users/enekofb/projects/github.com/weaveworks/homebrew-tap/Formula/gitops.rb as a formula.
==> Fetching gitops
==> Downloading https://github.com/weaveworks/weave-gitops/releases/download/v0.37.0/gitops-Darwin-arm64.tar.gz
Already downloaded: /Users/enekofb/Library/Caches/Homebrew/downloads/f49ca5e63c0ea4f1046fd40ca231f45d388b354026cdc60fdf251d2191f7c850--gitops-Darwin-arm64.tar.gz
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/gitops/0.37.0: 7 files, 65.3MB, built in 2 seconds
==> Running `brew cleanup gitops`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

➜  homebrew-tap git:(issues/36) gitops version                                                                                                   Current Version: 0.37.0
GitCommit: 3f850ced58c9fe9d593807e299058e0e06c735eb
BuildTime: 2023-11-22T13:24:19Z
Branch: releases/v0.37.0

```